### PR TITLE
send cookies along with keycloak.updateToken()

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -380,6 +380,7 @@
                         var req = new XMLHttpRequest();
                         req.open('POST', url, true);
                         req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                        req.withCredentials = true;
 
                         if (kc.clientId && kc.clientSecret) {
                             req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));


### PR DESCRIPTION
This patch causes keycloak.js's updateToken() function to send cookies along with its POST.  I opened this PR mostly for feedback and discussion.  I'm not sure this is a good idea in all cases.  Here's why I added it for our use case:

We have multiple keycloak nodes clustered behind a load balancer.  On first request, the load balancer sticks users to a node by handing a cookie to the browser.  Currently, when keycloak.js sends the updateToken() POST to the load balancer, it's a cross-origin call and thus the browser omits cookies.  As a result, the load balancer doesn't know which keycloak node to route the request to.

By setting `withCredentials = true`, the browser will send cookies to our keycloak load balancer so we can be routed properly.

What say you, keycloak team?  If this isn't desired behavior for all cases, I'd be happy to submit an alternate patch where sending cookies is an opt-in configuration parameter.
